### PR TITLE
chore: nix flake dependencies updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,18 @@
   "nodes": {
     "crypto3": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nix-3rdparty": "nix-3rdparty",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1718024088,
-        "narHash": "sha256-CMuiZC9ReLMz+RRyJKhfmATPklQxZaadZPN/i1RGPYY=",
+        "lastModified": 1721210207,
+        "narHash": "sha256-+A3HUNRxGe2UbgpsbRZUHMfZi7EubcoPigW7IRKUQqI=",
         "ref": "refs/heads/master",
-        "rev": "89246c5ba1db9f47a13e826ab5bcc840110fb390",
-        "revCount": 9140,
+        "rev": "9980a34b8a8a1fcde8bb0cf6108bff4eb65af062",
+        "revCount": 9159,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/crypto3"
@@ -43,7 +44,10 @@
     },
     "nix-3rdparty": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "crypto3",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "crypto3",
           "nixpkgs"
@@ -65,11 +69,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717530100,
-        "narHash": "sha256-b4Dn+PnrZoVZ/BoR9JN2fTxXxplJrAsdSUIePf4Cacs=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2e1d0414259a144ebdc048408a807e69e0565af",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
           ];
 
           propagatedBuildInputs = [
-            crypto3.packages.${system}.default
+            crypto3.packages.${system}.crypto3
           ];
 
           cmakeFlags = [
@@ -65,7 +65,7 @@
             clang
             gcc
             boost183
-            crypto3.packages.${system}.default
+            crypto3.packages.${system}.crypto3
           ];
 
           shellHook = ''


### PR DESCRIPTION
After crypto3 flake refactoring deafult target includes tests. To avoid running them, use             `crypto3.packages.${system}.crypto3` instead